### PR TITLE
Foco no post em tela cheia e compartilhamento de portfólio por tag

### DIFF
--- a/app/projects/DrawerTagsDesktop.tsx
+++ b/app/projects/DrawerTagsDesktop.tsx
@@ -1,6 +1,7 @@
 "use client";
 import IconMenu from '@/app/IconMenu';
 import { IconX } from '@/components/IconX';
+import ShareTagButton from '@/components/ShareTagButton';
 import { clsx } from 'clsx/lite';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -204,6 +205,10 @@ export default function DrawerTagsDesktop({ tags, selectedTag, setSelectedTag, m
                     <div className="flex-1 h-px bg-gray-200 dark:bg-neutral-700" />
                     <div className="flex-1 h-px bg-gray-200 dark:bg-neutral-700" />
                   </div>
+                )}
+                {/* Compartilhar portfólio da tag selecionada com um cliente */}
+                {selectedTag && (
+                  <ShareTagButton tag={selectedTag} />
                 )}
                 {/* Tags */}
                 {Array.isArray(tags) && tags.length > 0 && (

--- a/app/projects/DrawerTagsMobile.tsx
+++ b/app/projects/DrawerTagsMobile.tsx
@@ -1,6 +1,7 @@
 "use client";
 import IconMenu from '@/app/IconMenu';
 import { IconX } from '@/components/IconX';
+import ShareTagButton from '@/components/ShareTagButton';
 import { clsx } from 'clsx/lite';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -216,6 +217,10 @@ export default function DrawerTagsMobile({ tags, selectedTag, setSelectedTag, me
                                         <div className="flex-1 h-px bg-gray-200 dark:bg-neutral-700" />
                                         <div className="flex-1 h-px bg-gray-200 dark:bg-neutral-700" />
                                     </div>
+                                )}
+                                {/* Compartilhar portfólio da tag selecionada com um cliente */}
+                                {selectedTag && (
+                                    <ShareTagButton tag={selectedTag} />
                                 )}
                                 {/* Tags */}
                                 {Array.isArray(tags) && tags.length > 0 && (

--- a/src/components/ShareTagButton.tsx
+++ b/src/components/ShareTagButton.tsx
@@ -1,0 +1,83 @@
+"use client";
+import { clsx } from 'clsx/lite';
+import { useState } from 'react';
+import { BiCheck, BiShareAlt } from 'react-icons/bi';
+
+/**
+ * Botão para o artista compartilhar um portfólio filtrado por tag com um cliente.
+ * Monta a URL pública (/projects?tag=...), tenta o compartilhamento nativo do
+ * sistema (WhatsApp, e-mail, etc. no celular) e cai para copiar o link no desktop.
+ */
+export default function ShareTagButton({
+  tag,
+  className,
+  compact = false,
+}: {
+  tag: string;
+  className?: string;
+  /** Variante inline/compacta (ao lado da barra de filtro) em vez de bloco (drawer) */
+  compact?: boolean;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const buildUrl = () => {
+    if (typeof window === 'undefined') return '';
+    const url = new URL(`${window.location.origin}/projects`);
+    url.searchParams.set('tag', tag);
+    return url.toString();
+  };
+
+  const handleShare = async () => {
+    const url = buildUrl();
+    if (!url) return;
+
+    const shareData = {
+      title: 'Portfólio Wilbor',
+      text: `Confira este portfólio (${tag}):`,
+      url,
+    };
+
+    // Compartilhamento nativo (principalmente em celulares)
+    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+      try {
+        await navigator.share(shareData);
+        return;
+      } catch (err) {
+        // Usuário cancelou o menu nativo: não faz fallback
+        if ((err as Error)?.name === 'AbortError') return;
+        // Qualquer outro erro: cai para copiar o link
+      }
+    }
+
+    // Fallback desktop: copia o link para a área de transferência
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Último recurso, caso clipboard não esteja disponível
+      window.prompt('Copie o link do portfólio:', url);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleShare}
+      className={clsx(
+        'inline-flex items-center gap-2 rounded-full font-mono transition-colors',
+        'bg-red-600 text-white hover:bg-red-700 focus:outline-none',
+        compact
+          ? 'px-3 min-h-[40px] text-xs sm:text-sm'
+          : 'w-full justify-center px-4 py-3 rounded-lg text-base',
+        className
+      )}
+      style={{ outline: 'none', boxShadow: 'none', border: 'none' }}
+      aria-label={`Compartilhar portfólio da tag ${tag}`}
+      title={`Compartilhar portfólio da tag ${tag}`}
+    >
+      {copied ? <BiCheck size={compact ? 16 : 18} /> : <BiShareAlt size={compact ? 16 : 18} />}
+      <span>{copied ? 'Link copiado!' : compact ? 'Compartilhar' : 'Enviar portfólio'}</span>
+    </button>
+  );
+}

--- a/src/photo/PhotoProjectsContainer.tsx
+++ b/src/photo/PhotoProjectsContainer.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { IconX } from '@/components/IconX';
-import ImageCarousel from '@/components/ImageCarousel';
 import Markdown from '@/components/Markdown';
+import ShareTagButton from '@/components/ShareTagButton';
 import { MarkdownRenderer } from '@/lib/markdown/MarkdownRenderer';
 import '@/styles/slider-custom.css';
 import { clsx } from 'clsx/lite';
@@ -157,7 +157,6 @@ const MediaItem = ({
     const [isFullscreen, setIsFullscreen] = useState(false);
     const [mounted, setMounted] = useState(false);
     const [linkCopied, setLinkCopied] = useState(false);
-    const [currentImageIndex, setCurrentImageIndex] = useState(0);
     const images = getPostImages(mainItem);
 
     const handleCopyLink = useCallback(async (e: React.MouseEvent) => {
@@ -230,23 +229,10 @@ const MediaItem = ({
         const onKey = (e: KeyboardEvent) => {
             if (e.key === 'Escape') {
                 setIsFullscreen(false);
-            } else if (isFullscreen && images.length > 1) {
-                // Navegação por teclado apenas em desktop (largura >= 640px) e quando há mais de uma imagem
-                if (window.innerWidth >= 640) {
-                    if (e.key === 'ArrowLeft') {
-                        e.preventDefault();
-                        setCurrentImageIndex(prev => prev === 0 ? images.length - 1 : prev - 1);
-                    } else if (e.key === 'ArrowRight') {
-                        e.preventDefault();
-                        setCurrentImageIndex(prev => prev === images.length - 1 ? 0 : prev + 1);
-                    }
-                }
             }
         };
 
         if (!isFullscreen) {
-            // Reset do índice quando sair do fullscreen
-            setCurrentImageIndex(0);
             return;
         }
 
@@ -705,12 +691,11 @@ const MediaItem = ({
                                         )}
                                     </button>
                                 )} */}
-                                {/* Botão de zoom para abrir fullscreen reutilizando ImageCarousel */}
+                                {/* Botão de zoom para abrir o post inteiro em destaque central (tela cheia) */}
                                 {images.length > 0 && (
                                     <button
                                         onClick={e => {
                                             e.stopPropagation();
-                                            setCurrentImageIndex(0); // Reset do índice ao abrir fullscreen
                                             setIsFullscreen(true);
                                         }}
                                         className="p-1.5 sm:p-2 bg-transparent border-none shadow-none flex items-center justify-center hover:bg-transparent rounded-full transition-colors"
@@ -757,10 +742,10 @@ const MediaItem = ({
                 )}
 
             </div>
-            {/* Modal fullscreen renderizado via Portal fora do card */}
+            {/* Modal fullscreen renderizado via Portal fora do card: foca no post inteiro com destaque central */}
             {mounted && isFullscreen && typeof window !== 'undefined' && createPortal(
                 <div
-                    className="fixed top-0 left-0 right-0 z-[9999] flex items-center justify-center"
+                    className="fixed top-0 left-0 right-0 z-[9999] flex justify-center overflow-y-auto overscroll-contain"
                     onClick={() => setIsFullscreen(false)}
                     style={{
                         position: 'fixed',
@@ -770,7 +755,9 @@ const MediaItem = ({
                         width: '100vw',
                         height: 'var(--fullscreen-vh, 100svh)',
                         paddingBottom: 'env(safe-area-inset-bottom, 0px)',
-                        backgroundColor: '#000',
+                        backgroundColor: 'rgba(0, 0, 0, 0.85)',
+                        backdropFilter: 'blur(4px)',
+                        WebkitBackdropFilter: 'blur(4px)',
                     }}
                 >
                     {/* Botão de fechar no topo direito */}
@@ -786,21 +773,24 @@ const MediaItem = ({
                         <IconX size={35} />
                     </button>
 
+                    {/* Card do post centralizado e destacado */}
                     <div
-                        className="w-full h-[100dvh] max-w-none px-0 py-0 flex items-center justify-center lg:max-w-7xl lg:px-8 lg:py-20"
+                        className="relative z-[1] my-6 sm:my-12 w-full max-w-3xl lg:max-w-4xl bg-white dark:bg-black rounded-lg shadow-2xl overflow-hidden self-start"
                         onClick={e => e.stopPropagation()}
-                        style={{
-                            position: 'relative',
-                            zIndex: 1,
-                            height: 'var(--fullscreen-vh, 100svh)',
-                        }}
                     >
-                        <ImageCarousel
-                            images={images.map(src => ({ src, alt: mainItem.title || '' }))}
-                            fullscreen={true}
-                            currentIndex={currentImageIndex}
-                            onIndexChange={setCurrentImageIndex}
-                        />
+                        <div className="flex items-center px-4 sm:px-6 py-3 sm:py-4">
+                            <h2
+                                className="flex-1 text-base sm:text-xl md:text-2xl font-bold tracking-wide leading-tight !text-gray-500 dark:!text-[#888888]"
+                                style={{ fontFamily: 'IBMPlexMono, monospace' }}
+                            >
+                                {mainItem.title}
+                            </h2>
+                        </div>
+                        <div className="w-full text-left" style={{ margin: 0, padding: 0 }}>
+                            <Markdown videoPoster={updatedThumbnail || thumbnailUrl || undefined} inExpandedCard={true} hasLittleContent={!hasLargeContent}>
+                                {mainItem.hiveMetadata?.body ?? ''}
+                            </Markdown>
+                        </div>
                     </div>
                 </div>,
                 document.body
@@ -953,6 +943,31 @@ export default function PhotoGridContainer({
                 'bg-white dark:bg-neutral-950'
             )}>
                 {header}
+
+                {/* Barra de filtro ativo por tag */}
+                {selectedTag && (
+                    <div className="flex items-center gap-3 flex-wrap mb-6">
+                        <span className="font-mono text-xs uppercase tracking-wide text-gray-500 dark:text-zinc-500">
+                            Filtrando por
+                        </span>
+                        <button
+                            onClick={() => handleTagClick(selectedTag)}
+                            className="inline-flex items-center gap-2 min-h-[40px] px-4 rounded-full font-mono text-sm bg-neutral-900 text-white dark:bg-white dark:text-black border border-neutral-900 dark:border-white hover:opacity-90 active:scale-[0.98] transition-all duration-150 touch-manipulation"
+                            aria-label={`Remover filtro ${selectedTag}`}
+                            title={`Remover filtro ${selectedTag}`}
+                        >
+                            #{selectedTag}
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </button>
+                        <span className="font-mono text-xs text-gray-500 dark:text-zinc-500">
+                            {mediaGroups.length === 1 ? '1 projeto' : `${mediaGroups.length} projetos`}
+                        </span>
+                        {/* Compartilhar/copiar link do portfólio filtrado com um cliente */}
+                        <ShareTagButton tag={selectedTag} compact className="sm:ml-auto" />
+                    </div>
+                )}
 
                 <div className={clsx(
                     'grid',


### PR DESCRIPTION
## Resumo

Três entregas nesta branch:

### 1. Fix — Botão de tela cheia foca no post
Antes o botão abria um carrossel **apenas com as imagens** do card. Agora abre o **post inteiro** (título + corpo/markdown) num painel centralizado e destacado sobre fundo escuro com blur — um "modo foco" de leitura, scrollável. Removido o código que ficou sem uso (carrossel de imagens em fullscreen, navegação por setas, estado de índice).

### 2. Feature — Compartilhamento de portfólio por tag
Permite ao artista enviar a um cliente um link com o portfólio já filtrado por tag.
- Aproveita a URL que já carregava a tag (`/projects?tag=...`).
- Novo componente `ShareTagButton`: **compartilhamento nativo no mobile** (WhatsApp, e-mail…) e **copiar link no desktop** com feedback "Link copiado!".
- Disponível no **drawer de tags** e **inline na barra de filtro** (variante compacta).

### 3. Feature — Barra de filtro ativo (replicada do dashboard)
Ao selecionar uma tag aparece acima do grid: **FILTRANDO POR** · `#tag ✕` (X limpa o filtro) · **N projetos**. Cores adaptadas para o tema claro/escuro do blog.

## Arquivos
- `src/photo/PhotoProjectsContainer.tsx` — fullscreen do post + barra de filtro + botão inline
- `src/components/ShareTagButton.tsx` — novo componente (variantes bloco/compacta)
- `app/projects/DrawerTagsDesktop.tsx` e `app/projects/DrawerTagsMobile.tsx` — botão no drawer

## Verificação
- `next build` de produção passou (✓ compiled, ✓ types, 8/8 páginas estáticas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)