### PR TITLE
fix: botão de compartilhar branco e galeria empilhada no card

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,7 +1,6 @@
 import ReactMarkdown, { type Components } from 'react-markdown';
 import rehypeRaw from 'rehype-raw';
 import remarkGfm from 'remark-gfm';
-import ImageCarousel from './ImageCarousel';
 
 interface MarkdownProps {
     children: string;
@@ -486,16 +485,36 @@ export default function Markdown({ children, className = '', removeMedia = false
         >
             {blocks.map((block, idx) => {
                 if (block.type === 'carousel' && block.images && block.images.length > 0) {
+                    // Imagens empilhadas verticalmente (estilo PeakD), sem carousel
                     return (
                         <div
                             key={idx}
                             className={
                                 inExpandedCard
-                                    ? "my-0 w-full px-0"
-                                    : "my-6 first:mt-0 last:mb-0"
+                                    ? "my-0 w-full px-0 flex flex-col gap-4"
+                                    : "my-6 first:mt-0 last:mb-0 flex flex-col gap-4"
                             }
                         >
-                            <ImageCarousel images={block.images} inExpandedCard={inExpandedCard} hasLittleContent={hasLittleContent} />
+                            {block.images.map((image, imageIdx) => (
+                                <img
+                                    key={image.src + imageIdx}
+                                    src={image.src}
+                                    alt={image.alt || ''}
+                                    loading="lazy"
+                                    decoding="async"
+                                    className="!rounded-lg w-full max-w-full h-auto block"
+                                    style={{ borderRadius: '0.5rem' }}
+                                    onError={(e) => {
+                                        const img = e.currentTarget;
+                                        // Fallback para proxy Hive quando gateway original falhar (404/timeout).
+                                        if (!img.dataset.fallback) {
+                                            img.dataset.fallback = '1';
+                                            img.src = `https://images.hive.blog/0x0/${image.src}`;
+                                        }
+                                    }}
+                                    draggable={false}
+                                />
+                            ))}
                         </div>
                     );
                 }

--- a/src/components/ShareTagButton.tsx
+++ b/src/components/ShareTagButton.tsx
@@ -66,13 +66,13 @@ export default function ShareTagButton({
       onClick={handleShare}
       className={clsx(
         'inline-flex items-center gap-2 rounded-full font-mono transition-colors',
-        'bg-red-600 text-white hover:bg-red-700 focus:outline-none',
+        'bg-white text-black border border-gray-300 hover:bg-gray-100 focus:outline-none',
         compact
           ? 'px-3 min-h-[40px] text-xs sm:text-sm'
           : 'w-full justify-center px-4 py-3 rounded-lg text-base',
         className
       )}
-      style={{ outline: 'none', boxShadow: 'none', border: 'none' }}
+      style={{ outline: 'none', boxShadow: 'none' }}
       aria-label={`Compartilhar portfólio da tag ${tag}`}
       title={`Compartilhar portfólio da tag ${tag}`}
     >


### PR DESCRIPTION
## Mudanças

Dois ajustes de UI:

### 1. Botão de compartilhar: vermelho → branco
O `ShareTagButton` estava `bg-red-600` (vermelho, muito chamativo). Agora é branco com borda cinza (`bg-white text-black border border-gray-300`, hover `bg-gray-100`). Também removi o `border: 'none'` do estilo inline que apagava a borda.

### 2. Imagens dentro do card: carrossel → galeria empilhada
Ao expandir um card, as imagens consecutivas do post eram renderizadas num `ImageCarousel`. Agora são **empilhadas verticalmente** (estilo PeakD), aplicando a mesma solução já usada no repo do `wilbor.dashboard`.

- Mantém a lógica de `supplementalImages` que o blog já tinha
- Preserva o fallback de erro para o proxy `images.hive.blog`
- O componente `ImageCarousel` **não foi removido** (ainda é usado em `Footer.tsx`)

## Verificação
- `tsc --noEmit` sem erros nos arquivos alterados

🤖 Generated with [Claude Code](https://claude.com/claude-code)