### PR TITLE
fix: botão de compartilhar branco em vez de vermelho

### DIFF
--- a/src/components/ShareTagButton.tsx
+++ b/src/components/ShareTagButton.tsx
@@ -66,13 +66,13 @@ export default function ShareTagButton({
       onClick={handleShare}
       className={clsx(
         'inline-flex items-center gap-2 rounded-full font-mono transition-colors',
-        'bg-red-600 text-white hover:bg-red-700 focus:outline-none',
+        'bg-white text-black border border-gray-300 hover:bg-gray-100 focus:outline-none',
         compact
           ? 'px-3 min-h-[40px] text-xs sm:text-sm'
           : 'w-full justify-center px-4 py-3 rounded-lg text-base',
         className
       )}
-      style={{ outline: 'none', boxShadow: 'none', border: 'none' }}
+      style={{ outline: 'none', boxShadow: 'none' }}
       aria-label={`Compartilhar portfólio da tag ${tag}`}
       title={`Compartilhar portfólio da tag ${tag}`}
     >


### PR DESCRIPTION
## Mudança

O botão de compartilhar portfólio (`ShareTagButton`) estava vermelho (`bg-red-600`), muito chamativo. Agora é **branco com borda cinza** (hover em cinza claro), ficando mais discreto e alinhado ao restante do layout.

Também removi o `border: 'none'` do estilo inline, que apagava a borda do botão branco.

Apenas 1 arquivo alterado (`ShareTagButton.tsx`, 2 linhas). O carrossel de imagens dentro do card **foi mantido** intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)