### PR TITLE
fix: restaura carrossel de imagens dentro do card

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,6 +1,7 @@
 import ReactMarkdown, { type Components } from 'react-markdown';
 import rehypeRaw from 'rehype-raw';
 import remarkGfm from 'remark-gfm';
+import ImageCarousel from './ImageCarousel';
 
 interface MarkdownProps {
     children: string;
@@ -485,36 +486,16 @@ export default function Markdown({ children, className = '', removeMedia = false
         >
             {blocks.map((block, idx) => {
                 if (block.type === 'carousel' && block.images && block.images.length > 0) {
-                    // Imagens empilhadas verticalmente (estilo PeakD), sem carousel
                     return (
                         <div
                             key={idx}
                             className={
                                 inExpandedCard
-                                    ? "my-0 w-full px-0 flex flex-col gap-4"
-                                    : "my-6 first:mt-0 last:mb-0 flex flex-col gap-4"
+                                    ? "my-0 w-full px-0"
+                                    : "my-6 first:mt-0 last:mb-0"
                             }
                         >
-                            {block.images.map((image, imageIdx) => (
-                                <img
-                                    key={image.src + imageIdx}
-                                    src={image.src}
-                                    alt={image.alt || ''}
-                                    loading="lazy"
-                                    decoding="async"
-                                    className="!rounded-lg w-full max-w-full h-auto block"
-                                    style={{ borderRadius: '0.5rem' }}
-                                    onError={(e) => {
-                                        const img = e.currentTarget;
-                                        // Fallback para proxy Hive quando gateway original falhar (404/timeout).
-                                        if (!img.dataset.fallback) {
-                                            img.dataset.fallback = '1';
-                                            img.src = `https://images.hive.blog/0x0/${image.src}`;
-                                        }
-                                    }}
-                                    draggable={false}
-                                />
-                            ))}
+                            <ImageCarousel images={block.images} inExpandedCard={inExpandedCard} hasLittleContent={hasLittleContent} />
                         </div>
                     );
                 }


### PR DESCRIPTION
## Contexto

A galeria empilhada (estilo PeakD) que **removeu o carrossel** acabou subindo para produção pelo merge do #65 — a reversão que restaurava o carrossel não chegou ao `main`. O artista prefere o **carrossel**.

## Mudança

Restaura o `Markdown.tsx` para usar o `ImageCarousel` original ao exibir imagens consecutivas dentro do card expandido, em vez da galeria empilhada.

- Apenas 1 arquivo alterado (`Markdown.tsx`)
- O botão de compartilhar branco (já em produção) é **mantido**
- Volta exatamente ao comportamento de carrossel anterior

🤖 Generated with [Claude Code](https://claude.com/claude-code)