### PR TITLE
feat: barra de aviso de site em construção

### DIFF
--- a/app/components/ConstructionBanner.tsx
+++ b/app/components/ConstructionBanner.tsx
@@ -1,0 +1,37 @@
+const PORTFOLIO_URL = 'https://cargocollective.com/wilbor';
+
+export default function ConstructionBanner() {
+  return (
+    <div
+      className={[
+        'w-full border-b',
+        'border-neutral-200 dark:border-neutral-800',
+        'bg-neutral-100 dark:bg-neutral-900',
+        'text-neutral-600 dark:text-neutral-400',
+      ].join(' ')}
+    >
+      <p
+        className={[
+          'mx-auto max-w-7xl',
+          'px-4 py-2',
+          'text-center text-xs',
+        ].join(' ')}
+      >
+        Site em construção. Enquanto isso, acesse o{' '}
+        <a
+          href={PORTFOLIO_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={[
+            'underline underline-offset-2',
+            'text-neutral-900 dark:text-neutral-100',
+            'hover:opacity-70',
+          ].join(' ')}
+        >
+          portfólio completo
+        </a>
+        .
+      </p>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,7 @@ import { Metadata } from 'next/types';
 import '../tailwind.css';
 import '../styles/markdown-contact.css';
 import '../src/styles/exhibitions.css';
+import ConstructionBanner from './components/ConstructionBanner';
 import JsonLd from './components/JsonLd';
 
 export const metadata: Metadata = {
@@ -90,6 +91,7 @@ export default function RootLayout({
       </head>
       <body className="bg-main">
           <ThemeProvider attribute="class" defaultTheme={DEFAULT_THEME}>
+              <ConstructionBanner />
               <main >
                 <div className="flex flex-col items-center">
                 </div>


### PR DESCRIPTION
Adiciona uma barra fina no topo de todas as páginas avisando que o site ainda está em construção, com link para o portfólio completo no Cargo Collective.

> Site em construção. Enquanto isso, acesse o [portfólio completo](https://cargocollective.com/wilbor).

## Motivo

O site precisa ser mostrado a um cliente antes de estar pronto. A barra deixa o estado explícito e oferece um caminho imediato para o portfólio que já está completo.

## Alterações

- `app/components/ConstructionBanner.tsx` (novo) — a barra
- `app/layout.tsx` — import e renderização antes do `<main>`

Como está no layout raiz, aparece em todas as páginas.

## Detalhes

- O link abre em nova aba (`target="_blank"` + `rel="noopener noreferrer"`), então o visitante não perde o site ao clicar
- Segue o padrão visual do rodapé (`text-neutral-*` com variante `dark:`), acompanhando o tema claro/escuro
- Sem dependências novas; nada depende do Cargo estar no ar — se ele cair, apenas o link não abre

## Como reverter

Remover as duas linhas em `app/layout.tsx` e apagar o componente.

## Verificado

- Rodado localmente (`next dev`), barra renderizando em todas as páginas
- `tsc --noEmit` limpo (os erros restantes em `__tests__/` são pré-existentes, falta `@types/jest`)