### PR TITLE
fix: corrige quebra de linha da barra de construção no mobile

### DIFF
--- a/app/components/ConstructionBanner.tsx
+++ b/app/components/ConstructionBanner.tsx
@@ -23,6 +23,11 @@ export default function ConstructionBanner() {
           target="_blank"
           rel="noopener noreferrer"
           className={[
+            // No mobile o link vira bloco: cai numa linha própria e o
+            // text-center do pai o centraliza. A partir de sm volta a fluir
+            // na mesma linha da frase.
+            'block sm:inline',
+            'mt-1 sm:mt-0',
             'underline underline-offset-2',
             'text-neutral-900 dark:text-neutral-100',
             'hover:opacity-70',
@@ -30,7 +35,6 @@ export default function ConstructionBanner() {
         >
           portfólio completo
         </a>
-        .
       </p>
     </div>
   );


### PR DESCRIPTION
Ajuste de follow-up do #70.

## Problema

No mobile a frase quebrava no meio do link, separando "portfólio" de "completo" em linhas diferentes:

```
Site em construção. Enquanto isso, acesse o portfólio
                    completo.
```

## Solução

O link passa a ser bloco abaixo do breakpoint `sm`, caindo numa linha própria e centralizado pelo `text-center` que o container já tem:

```
        Site em construção. Enquanto isso, acesse o
                 portfólio completo
```

A partir de `sm` volta a fluir na mesma linha da frase — o desktop não muda.

## Alterações

Só o `className` do link em `app/components/ConstructionBanner.tsx`:

- `block sm:inline` — linha própria no mobile
- `mt-1 sm:mt-0` — respiro entre a frase e o link

O ponto final foi removido: com o link em bloco, ele sobraria sozinho numa terceira linha.

## Efeito colateral positivo

Como `block` ocupa a largura toda, a área de toque do link no mobile ficou bem maior — antes era só a extensão do texto.

## Verificado

- Rodado localmente (`next dev`), classes aplicadas e página em 200
- Desktop inalterado